### PR TITLE
feat: Added SEO related meta tags

### DIFF
--- a/src/routes/gallery/index.svelte
+++ b/src/routes/gallery/index.svelte
@@ -1,3 +1,10 @@
+<svelte:head>
+	<meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Pixel VG - Image Gallery</title>
+	<meta name="description" content="Image gallery with example images.">
+</svelte:head>
 <script lang="ts">
 	import { assets } from '$app/paths';
 	import images from './images';

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,3 +1,11 @@
+<svelte:head>
+	<meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Pixel VG - WebGL Pixel Editor</title>
+	<meta name="description" content="Pixel (V)ector (G)raphics Easy to use point & click pixel-art editor.">
+</svelte:head>
+
 <script lang="ts">
 	import Controls from '$lib/controls.svelte';
 	import DrawingBoard from '$lib/drawing-board.svelte';


### PR DESCRIPTION
Add title, description, and common meta tags for main page & gallery page

Closes #11 

**Note:** We can go with the common template approach if more pages are present. But, considering the current routes just added using the default svelte way of adding in head. 